### PR TITLE
Replace dockerhub available tags link

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Install [Docker](https://www.docker.com/products/docker-desktop/) and configure 
     ```
     docker run --init -it --rm -v chaste_data:/home/chaste chaste/release
     ```
-    If needed, you can also specify an [available tag](https://hub.docker.com/repository/docker/chaste/release/tags) in the image name in the form `chaste/release:<tag>` to pull a particular release (e.g. `chaste/release:2024.1`) rather than defaulting to the latest version. 
+    If needed, you can also specify an [available tag](https://hub.docker.com/r/chaste/release/tags) in the image name in the form `chaste/release:<tag>` to pull a particular release (e.g. `chaste/release:2024.1`) rather than defaulting to the latest version. 
 2. Alternatively, if you want to use the latest development code from the `develop` branch, use this command to pull and run the latest `chaste/develop` image instead:
     ```
     docker run --init -it --rm -v chaste_data:/home/chaste chaste/develop


### PR DESCRIPTION
Replaces a docker hub link which requires login to a publicly accessible link


---

https://hub.docker.com/repository/docker/chaste/release/tags

![image](https://github.com/Chaste/chaste-docker/assets/628937/5402262c-f231-4799-b812-316cef370ee7)


https://hub.docker.com/r/chaste/release/tags

![image](https://github.com/Chaste/chaste-docker/assets/628937/80ba7af7-fb24-4423-9b08-e5514afb98fc)

