### PR TITLE
Upgrade to Resolute Racoon

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -14,11 +14,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       # https://github.com/actions/checkout/
     - name: Docker meta
       id: meta
-      uses: docker/metadata-action@v5
+      uses: docker/metadata-action@v6
       # https://github.com/docker/metadata-action
       with:
         images: |
@@ -41,21 +41,21 @@ jobs:
           org.opencontainers.image.source=https://github.com/Chaste/chaste-docker
 
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v3
+      uses: docker/setup-qemu-action@v4
       # https://github.com/docker/setup-qemu-action
       with:
         platforms: 'amd64,arm64'
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@v4
       # https://github.com/docker/setup-buildx-action
     - name: Login to DockerHub
-      uses: docker/login-action@v3
+      uses: docker/login-action@v4
       # https://github.com/docker/login-action
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
     - name: Build and push the Docker image
-      uses: docker/build-push-action@v5
+      uses: docker/build-push-action@v7
       # https://github.com/docker/build-push-action
       with:
         context: .

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -3,7 +3,7 @@ name: Build chaste/base
 on:
   push:
     branches: [ "master" ]
-    tags: "v*"
+    tags: [ "v*" ]
   pull_request:
     branches: [ "master" ]
   schedule:

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -32,7 +32,7 @@ jobs:
           type=semver,pattern={{major}}.{{minor}}
           type=semver,pattern={{major}}
           # Update the following line to match the base ubuntu image
-          type=raw,value=questing
+          type=raw,value=resolute
           type=sha
         labels: |
           org.opencontainers.image.title=Chaste Base Image

--- a/Dockerfile
+++ b/Dockerfile
@@ -57,6 +57,7 @@ RUN wget -O /usr/share/keyrings/chaste.asc https://chaste.github.io/chaste.asc \
 # Install dependencies with applicable recommended and other useful packages
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
+    build-essential \
     chaste-dependencies \
     clang \
     lldb \

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@
 # Run the image (with a named volume and process management enabled)
 # docker run -it --init --rm -v chaste_data:/home/chaste chaste
 
-ARG BASE=questing
+ARG BASE=resolute
 FROM ubuntu:${BASE} AS base
 LABEL maintainer="Ben Evans <ben.d.evans@gmail.com>" \
     author.orcid="https://orcid.org/0000-0002-1734-6070" \

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ help:
 
 
 BASE ?= resolute
-GIT_TAG ?= 2024.2
+GIT_TAG ?= 2026.1
 TEST_SUITE ?= -
 CHASTE_IMAGE ?= chaste/release
 CHASTE_DIR ?= "/home/chaste"

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ help:
 	@echo "  make [TARGET] -n"
 
 
-BASE ?= questing
+BASE ?= resolute
 GIT_TAG ?= 2024.2
 TEST_SUITE ?= -
 CHASTE_IMAGE ?= chaste/release

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Install [Docker](https://www.docker.com/products/docker-desktop/) and configure 
     ```
     docker run --init -it --rm -v chaste_data:/home/chaste chaste/release
     ```
-    If needed, you can also specify an [available tag](https://hub.docker.com/r/chaste/release/tags) in the image name in the form `chaste/release:<tag>` to pull a particular release (e.g. `chaste/release:2024.2`) rather than defaulting to the latest version. 
+    If needed, you can also specify an [available tag](https://hub.docker.com/r/chaste/release/tags) in the image name in the form `chaste/release:<tag>` to pull a particular release (e.g. `chaste/release:2026.1`) rather than defaulting to the latest version. 
 2. Alternatively, if you want to use the latest development code from the `develop` branch, use this command to pull and run the latest `chaste/develop` image instead:
     ```
     docker run --init -it --rm -v chaste_data:/home/chaste chaste/develop
@@ -153,7 +153,7 @@ For further details and illustrations of the Docker mount options see the [stora
 
 ### Bind mounts
 
-Any host directory (specified with an absolute path e.g. `/path/to/output`) may be mounted in the container e.g. the `output` directory. Alternatively, navigate to the folder on the host which contains these directories e.g. `C:\Users\$USERNAME\chaste` (Windows) or `~/chaste` (Linux/macOS) and use `$(pwd)/output` instead as shown below. In the following examples, the image name (final argument) is assumed to be `chaste/release` rather than e.g. `chaste/develop` or `chaste/release:2024.2` for simplicity. 
+Any host directory (specified with an absolute path e.g. `/path/to/output`) may be mounted in the container e.g. the `output` directory. Alternatively, navigate to the folder on the host which contains these directories e.g. `C:\Users\$USERNAME\chaste` (Windows) or `~/chaste` (Linux/macOS) and use `$(pwd)/output` instead as shown below. In the following examples, the image name (final argument) is assumed to be `chaste/release` rather than e.g. `chaste/develop` or `chaste/release:2026.1` for simplicity. 
 ```
 docker run -it --init --rm -v chaste_data:/home/chaste -v "${PWD}"/output:/home/chaste/output chaste/release
 ```
@@ -230,7 +230,7 @@ If you're a more advanced developer and want to build your own image with a part
         ```
     2. Alternatively a specific branch or tag may be specified through the argument `--build-arg GIT_TAG=<branch|tag>` (with the same tag appended onto the docker image name for clarity) e.g.:
         ```
-        docker build -t chaste:custom --build-arg GIT_TAG=2024.2 https://github.com/chaste/chaste-docker.git
+        docker build -t chaste:custom --build-arg GIT_TAG=2026.1 https://github.com/chaste/chaste-docker.git
         ```
     3. Finally, if you want a bare container ready for you to clone and compile your own Chaste code, pull a `base` image with `docker pull chaste/base` (specifying an [available Ubuntu distribution](https://hub.docker.com/repository/docker/chaste/base/tags) if desired e.g. `chaste/base:focal`) Alternatively, build a fresh image by running the following command (omitting the `--build-arg GIT_TAG=<branch|tag>` argument above, or explicitly passing `--build-arg GIT_TAG=-`, which will skip compiling Chaste within the image):
         ```


### PR DESCRIPTION
Note: `build-essential` had to be added for `make` (and possibly `gcc` & `g++`) so `chaste-dependencies` should be updated to include the packages that were dropped in `resolute`.